### PR TITLE
disable linking with msvc runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ if(MSVC)
 endif()
 
 set_default_configuration_release()
-msvc_use_static_runtime()
 
 # dmlc-core option
 include(dmlc-core/cmake/Utils.cmake)

--- a/runtime/native/CMakeLists.txt
+++ b/runtime/native/CMakeLists.txt
@@ -14,7 +14,6 @@ if(MSVC)
 endif()
 
 set_default_configuration_release()
-msvc_use_static_runtime()
 
 option(ENABLE_S3 "Build with S3 support" OFF)
 option(TEST_COVERAGE "C++ test coverage" OFF)


### PR DESCRIPTION
This patch disables linking treelite with msvc static runtime. 

This enables downstream applications to link with msvc runtime dynamically.